### PR TITLE
add_t_cell_cutoff_function

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ usage: topogtools min_dy --input <input_file> --output <output_file> --cutoff <c
 Convert ocean cells into land if their y size is smaller than `<cutoff_value>`, expressed in the same units as `dy` in `<hgrid_file>` (typically metres).
 
 Options
-  * `--hgrid <hgrid>`  vertical grid (default 'ocean_hgrid.nc')
+  * `--hgrid <hgrid_file>`  horizontal supergrid file (default 'ocean_hgrid.nc')
 
 # Building and Installation
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Options
 usage: topogtools min_dy --input <input_file> --output <output_file> --hgrid <grid> --cutoff <cutoff_value>       
 ```
 
-Convert ocean cells into land if their y size is smaller than <cutoff_value> metres.
+Convert ocean cells into land if their y size is smaller than `<cutoff_value>`, expressed in the same units as `dy` in `<hgrid_file>` (typically metres).
 
 Options
   * `--hgrid <hgrid>`  vertical grid (default 'ocean_hgrid.nc')

--- a/README.md
+++ b/README.md
@@ -116,14 +116,9 @@ Options
 
 ```
 usage: topogtools mask  --input <input_file> --output <output_file>
-                        [--fraction <frac>]
 ```
 
 Creates a land mask from a topography.
-
-Options
-  * `--fraction <frac>`  cells with a fraction of sea area smaller than `<frac>` will be set as land (default '0.0')
-
 
 ## float_vgrid
 
@@ -144,6 +139,9 @@ usage: topogtools min_dy --input <input_file> --output <output_file> --hgrid <gr
 ```
 
 Convert ocean cells into land if their y size is smaller than <cutoff_value> metres.
+
+Options
+  * `--hgrid <hgrid>`  vertical grid (default 'ocean_hgrid.nc')
 
 # Building and Installation
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Options
 usage: topogtools min_dy --input <input_file> --output <output_file> --hgrid <grid> --cutoff <cutoff_value>       
 ```
 
-Cut off T cells with size smaller than <cutoff_value>. Cut off should be in kilometers
+Convert ocean cells into land if their y size is smaller than <cutoff_value> kilometres.
 
 # Building and Installation
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Options
 usage: topogtools min_dy --input <input_file> --output <output_file> --hgrid <grid> --cutoff <cutoff_value>       
 ```
 
-Convert ocean cells into land if their y size is smaller than <cutoff_value> kilometres.
+Convert ocean cells into land if their y size is smaller than <cutoff_value> metres.
 
 # Building and Installation
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ double-precision topography file.
 Options
   * `--vgrid <vgrid>`  vertical grid (default 'ocean_vgrid.nc')
 
+## cut_off_T_cells
+
+```
+usage: topogtools cut_off_T_cells --input <input_file> --output <output_file> --hgrid <grid> --cutoff <cutoff_value>       
+```
+
+Cut off T cells with size smaller than <cutoff_value>. Cut off should be in kilometers
 
 # Building and Installation
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ double-precision topography file.
 Options
   * `--vgrid <vgrid>`  vertical grid (default 'ocean_vgrid.nc')
 
-## cut_off_T_cells
+## min_dy
 
 ```
-usage: topogtools cut_off_T_cells --input <input_file> --output <output_file> --hgrid <grid> --cutoff <cutoff_value>       
+usage: topogtools min_dy --input <input_file> --output <output_file> --hgrid <grid> --cutoff <cutoff_value>       
 ```
 
 Cut off T cells with size smaller than <cutoff_value>. Cut off should be in kilometers

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Options
 ## min_dy
 
 ```
-usage: topogtools min_dy --input <input_file> --output <output_file> --hgrid <grid> --cutoff <cutoff_value>       
+usage: topogtools min_dy --input <input_file> --output <output_file> --cutoff <cutoff_value>
+                        [--hgrid <hgrid_file>]
 ```
 
 Convert ocean cells into land if their y size is smaller than `<cutoff_value>`, expressed in the same units as `dy` in `<hgrid_file>` (typically metres).

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -496,7 +496,7 @@ contains
     ! Apply cutoff to depth based on the provided T-cell cutoff value
     do j = 1, ny_len / 2
       do i = 1, (nxp_len - 1) / 2
-          if (dy(2 * i - 1, 2 * j) + dy(2 * i, 2 * j) < cutoff) then  !Input cutoff in meters
+          if (dy(2 * i - 1, 2 * j) + dy(2 * i, 2 * j) < cutoff) then
             this%depth(i, j) = MISSING_VALUE  ! Set values below cutoff to zero or another value as needed
           end if
         end do

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -481,8 +481,8 @@ contains
     call handle_error(nf90_open(trim(hgrid), nf90_nowrite, ncid_hgrid))
     call handle_error(nf90_inq_varid(ncid_hgrid, 'dy', dy_id))
     call handle_error(nf90_inquire_variable(ncid_hgrid, dy_id, dimids=dids_dy))
-    call handle_error(nf90_inquire_dimension(ncid_hgrid, dids_dy(1), len=ny_len))
-    call handle_error(nf90_inquire_dimension(ncid_hgrid, dids_dy(2), len=nxp_len))
+    call handle_error(nf90_inquire_dimension(ncid_hgrid, dids_dy(1), len=nxp_len))
+    call handle_error(nf90_inquire_dimension(ncid_hgrid, dids_dy(2), len=ny_len))
 
     ! Allocate memory for dy based on its dimensions
     allocate(dy(nxp_len, ny_len))

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -471,7 +471,7 @@ contains
     real(real64), intent(in) :: cutoff
 
     integer(int32) :: i, j
-    integer(int32) :: ncid_hgrid, dy_id          ! NetCDF ids for hgrid
+    integer(int32) :: ncid_hgrid, dy_id          ! NetCDF ids for hgrid and dy
     integer(int32) :: dids_dy(2)                 ! NetCDF ids for dimensions
     integer(int32) :: ny_len, nxp_len, nx_len    ! dimensions for hgrid
     real(real64), allocatable :: dy(:,:)         ! To store dy variable from hgrid

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -485,7 +485,7 @@ contains
     call handle_error(nf90_inquire_dimension(ncid_hgrid, dids_dy(2), len=nxp_len))
 
     ! Allocate memory for dy based on its dimensions
-    allocate(dy(ny_len, nxp_len))
+    allocate(dy(nxp_len, ny_len))
 
     ! Read the dy variable from hgrid
     call handle_error(nf90_get_var(ncid_hgrid, dy_id, dy))
@@ -494,8 +494,8 @@ contains
     ! Calculate T cell size based on dy
     ! For each point, the T cell size is a sum of dy(2*i-1, 2*j) and dy(2*i, 2*j)    
     ! Apply cutoff to depth based on the provided T-cell cutoff value in meters
-    do i = 1, ny_len / 2
-      do j = 1, (nxp_len - 1) / 2
+    do j = 1, ny_len / 2
+      do i = 1, (nxp_len - 1) / 2
           if (dy(2 * i - 1, 2 * j) + dy(2 * i, 2 * j) < cutoff) then  !Input cutoff in meters
             this%depth(i, j) = MISSING_VALUE  ! Set values below cutoff to zero or another value as needed
           end if

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -493,7 +493,7 @@ contains
 
     ! Calculate T cell size based on dy
     ! For each point, the T cell size is a sum of dy(2*i-1, 2*j) and dy(2*i, 2*j)    
-    ! Apply cutoff to depth based on the provided T-cell cutoff value in meters
+    ! Apply cutoff to depth based on the provided T-cell cutoff value
     do j = 1, ny_len / 2
       do i = 1, (nxp_len - 1) / 2
           if (dy(2 * i - 1, 2 * j) + dy(2 * i, 2 * j) < cutoff) then  !Input cutoff in meters

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -506,10 +506,10 @@ contains
     ! Apply cutoff to depth based on the provided T-cell cutoff value in kilometers
     do i = 1, int(ny_len / 2)
       do j = 1, int((nxp_len - 1) / 2)
-            if (dy_t(i, j) < cutoff*1000.0) then  !Input cutoff in Kilometers covert it to meters
-              this%depth(i, j) = MISSING_VALUE  ! Set values below cutoff to zero or another value as needed
-            end if
-        end do
+        if (dy_t(i, j) < cutoff*1000.0_real64) then  !Input cutoff in Kilometers covert it to meters
+          this%depth(i, j) = MISSING_VALUE  ! Set values below cutoff to zero or another value as needed
+        end if
+      end do
     end do
 
 end subroutine topography_cut_off_T_cells

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -493,10 +493,10 @@ contains
 
     ! Calculate T cell size based on dy
     ! For each point, the T cell size is a sum of dy(2*i-1, 2*j) and dy(2*i, 2*j)    
-    ! Apply cutoff to depth based on the provided T-cell cutoff value in kilometers
+    ! Apply cutoff to depth based on the provided T-cell cutoff value in meters
     do i = 1, ny_len / 2
       do j = 1, (nxp_len - 1) / 2
-          if (dy(2 * i - 1, 2 * j) + dy(2 * i, 2 * j) < cutoff*1000.0_real64) then  !Input cutoff in Kilometers covert it to meters
+          if (dy(2 * i - 1, 2 * j) + dy(2 * i, 2 * j) < cutoff) then  !Input cutoff in meters
             this%depth(i, j) = MISSING_VALUE  ! Set values below cutoff to zero or another value as needed
           end if
         end do

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -35,7 +35,7 @@ module topography
     procedure :: nonadvective => topography_nonadvective
     procedure :: min_max_depth => topography_min_max_depth
     procedure :: mask => topography_mask
-    procedure :: cut_off_T_cells => topography_cut_off_T_cells
+    procedure :: min_dy => topography_min_dy
   end type topography_t
 
   interface topography_t
@@ -465,7 +465,7 @@ contains
 
   end subroutine topography_min_max_depth
 
- subroutine topography_cut_off_T_cells(this, hgrid, cutoff)
+ subroutine topography_min_dy(this, hgrid, cutoff)
     class(topography_t), intent(inout) :: this
     character(len=*), intent(in) :: hgrid
     real(real64), intent(in) :: cutoff
@@ -502,7 +502,7 @@ contains
         end do
     end do   
 
-end subroutine topography_cut_off_T_cells
+end subroutine topography_min_dy
 
   !-------------------------------------------------------------------------
   subroutine topography_fill_fraction(this, sea_area_fraction)

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -478,7 +478,7 @@ contains
     real(real64), allocatable :: dy_t(:,:)       ! To store dy_t (new array)
 
     ! Read hgrid to get dy
-    print*, 'Attempting to open:', trim(hgrid)
+    write(output_unit,'(3a)') "Attempting to open file '", trim(hgrid), "'"
     call handle_error(nf90_open(trim(hgrid), nf90_nowrite, ncid_hgrid))
     call handle_error(nf90_inq_varid(ncid_hgrid, 'dy', dy_id))
     call handle_error(nf90_inquire_variable(ncid_hgrid, dy_id, dimids=dids_dy))

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -499,7 +499,7 @@ contains
 
     do i = 1, int(ny_len / 2)
       do j = 1, int((nxp_len - 1) / 2)
-          dy_t(i, j) = dy(2 * i - 1, 2 * j) + dy(2 * i, 2 * j)
+        dy_t(i, j) = dy(2 * i - 1, 2 * j) + dy(2 * i, 2 * j)
       end do
     end do
   

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -470,7 +470,7 @@ contains
     character(len=*), intent(in) :: hgrid
     real(real64), intent(in) :: cutoff
 
-    integer(int32) :: i,j
+    integer(int32) :: i, j
     integer(int32) :: ncid_hgrid, dy_id          ! NetCDF ids for hgrid
     integer(int32) :: dids_dy(2)                 ! NetCDF ids for dimensions
     integer(int32) :: ny_len, nxp_len, nx_len    ! dimensions for hgrid

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -116,8 +116,9 @@ program topogtools
     '                                  --cutoff <cutoff_value>        ', &
     '                                  [--hgrid <hgrid_file>]        ', &
     '                                                                                ', &
-    'Convert ocean cells into land if their y size is less than <cutoff_value> in    ', &
-    'kilometres. Writes the result to <output_file>.                                 ', &
+    'Convert ocean cells into land if their y size is less than <cutoff_value>,      ', &
+    'expressed in the same units as dy in <hgrid_file> (typically metres).           ', &
+    'Writes the result to <output_file>.                                             ', &
     '                                                                                ', &
     'Options                                                                         ', &
     '   --hgrid <hgrid_file>     horizontal supergrid (default ''ocean_hgrid.nc'')   ', &

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -236,7 +236,7 @@ program topogtools
       error stop
     end if  
     topog = topography_t(file_in)
-    call topog%cut_off_T_cells(hgrid,cutoff)
+    call topog%cut_off_T_cells(hgrid, cutoff)
     call topog%update_history(get_mycommand())
     call topog%write(file_out)
 

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -115,9 +115,12 @@ program topogtools
     'usage: topogtools cut_off_T_cells --input <input_file> --output <output_file>   ', &
     '                                  --hgrid <grid> --cutoff <cutoff_value>        ', &
     '                                                                                ', &
-    'Cut off T cells with size smaller than <cutoff_value>. Writes the               ', &
-    'result to <output_file>.                                                        ', &
-    'Cut off should be in kilometers']
+    'Convert ocean cells into land if their y size is less than <cutoff_value> in    ', &
+    'kilometres. Writes the result to <output_file>.                                 ', &
+    '                                                                                ', &
+    'Options                                                                         ', &
+    '   --hgrid <hgrid_file>     horizontal supergrid (default ''ocean_hgrid.nc'')   ', &
+    '']
 
   ! Read command line
   name = get_subcommand()

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -144,7 +144,7 @@ program topogtools
       help_check_nonadvective, version_text)
   case ('mask')
     call set_args('--input:i "unset" --output:o "unset"', help_mask, version_text)
-  case ('cut_off_T_cells')
+  case ('min_dy')
     call set_args('--input:i "unset" --output:o "unset" --hgrid "ocean_hgrid.nc" --cutoff 0.0', help_cutoff, version_text)
   case ('')
     ! Print help in case the user specified the --help flag
@@ -226,7 +226,7 @@ program topogtools
     topog = topography_t(file_in)
     call topog%mask(file_out)
 
-  case ('cut_off_T_cells')
+  case ('min_dy')
     hgrid = sget('hgrid')
     call check_file_exist(hgrid)
     cutoff = rget('cutoff')
@@ -240,7 +240,7 @@ program topogtools
       error stop
     end if  
     topog = topography_t(file_in)
-    call topog%cut_off_T_cells(hgrid, cutoff)
+    call topog%min_dy(hgrid, cutoff)
     call topog%update_history(get_mycommand())
     call topog%write(file_out)
 

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -34,7 +34,7 @@ program topogtools
     '  check_nonadvective - Check for non-advective cells                            ', &
     '  fix_nonadvective - Fix non-advective cells                                    ', &
     '  mask - Generate mask                                                          ', &
-    '  cut_off_T_cells - Cut off T cells below a certain cell size                   ', &
+    '  min_dy - Set small ocean cells to land                                        ', &
     '']
   help_gen_topo = [character(len=80) :: &
     'usage: topogtools gen_topo --input <input_file> --output <output_file>          ', &

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -112,9 +112,9 @@ program topogtools
     '']
 
   help_cutoff = [character(len=80) :: &
-    'usage: topogtools min_dy --input <input_file> --output <output_file>   ', &
-    '                                  --cutoff <cutoff_value>        ', &
-    '                                  [--hgrid <hgrid_file>]        ', &
+    'usage: topogtools min_dy --input <input_file> --output <output_file>            ', &
+    '                                  --cutoff <cutoff_value>                       ', &
+    '                                  [--hgrid <hgrid_file>]                        ', &
     '                                                                                ', &
     'Convert ocean cells into land if their y size is less than <cutoff_value>,      ', &
     'expressed in the same units as dy in <hgrid_file> (typically metres).           ', &

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -112,7 +112,7 @@ program topogtools
     '']
 
   help_cutoff = [character(len=80) :: &
-    'usage: topogtools cut_off_T_cells --input <input_file> --output <output_file>   ', &
+    'usage: topogtools min_dy --input <input_file> --output <output_file>   ', &
     '                                  --cutoff <cutoff_value>        ', &
     '                                  [--hgrid <hgrid_file>]        ', &
     '                                                                                ', &

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -113,7 +113,8 @@ program topogtools
 
   help_cutoff = [character(len=80) :: &
     'usage: topogtools cut_off_T_cells --input <input_file> --output <output_file>   ', &
-    '                                  --hgrid <grid> --cutoff <cutoff_value>        ', &
+    '                                  --cutoff <cutoff_value>        ', &
+    '                                  [--hgrid <hgrid_file>]        ', &
     '                                                                                ', &
     'Convert ocean cells into land if their y size is less than <cutoff_value> in    ', &
     'kilometres. Writes the result to <output_file>.                                 ', &


### PR DESCRIPTION
This PR adds a subroutine to remove smaller T cells, particularly in regions near the tripole where smaller grid cells contribute to instability. These cells were previously removed in OM2 to enhance stability, and this change has now been incorporated into `domain-tools` in the current PR.