### PR TITLE
Fix compilation

### DIFF
--- a/src/float_vgrid.f90
+++ b/src/float_vgrid.f90
@@ -1,8 +1,8 @@
 program float_vgrid
   ! Zeta is double precision. Convert to  single and rewrite. This stops small floating point errors.
   use M_CLI2
-  use vgrid
-  use utils
+  use vgrid_m
+  use utils_m
   implicit none
 
   type(vgrid_t) :: vgrid

--- a/src/gen_topo.f90
+++ b/src/gen_topo.f90
@@ -13,7 +13,7 @@ module gen_topo_m
   !
   use iso_fortran_env
   use netcdf
-  use utils
+  use utils_m
   implicit none
 
   private

--- a/src/topography.f90
+++ b/src/topography.f90
@@ -1,8 +1,8 @@
-module topography
+module topography_m
   use iso_fortran_env
   use netcdf
-  use utils
-  use vgrid
+  use utils_m
+  use vgrid_m
   implicit none
 
   type topography_t
@@ -761,4 +761,4 @@ end subroutine topography_min_dy
 
   end subroutine topography_mask
 
-end module topography
+end module topography_m

--- a/src/topogtools.f90
+++ b/src/topogtools.f90
@@ -2,7 +2,7 @@ program topogtools
   use, intrinsic :: iso_fortran_env
   use M_CLI2
   use gen_topo_m
-  use topography
+  use topography_m
   implicit none
 
   character(len=5), PARAMETER :: VERSION = "1.0.0"

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -1,4 +1,4 @@
-module utils
+module utils_m
   use iso_fortran_env
   use netcdf
   implicit none
@@ -119,4 +119,4 @@ contains
 
   end function get_mycommand
 
-end module utils
+end module utils_m

--- a/src/vgrid.f90
+++ b/src/vgrid.f90
@@ -1,7 +1,7 @@
-module vgrid
+module vgrid_m
   use iso_fortran_env
   use netcdf
-  use utils
+  use utils_m
   implicit none
 
   private
@@ -207,4 +207,4 @@ contains
   end subroutine vgrid_float
 
 
-end module vgrid
+end module vgrid_m


### PR DESCRIPTION
Append _m to all modules to avoid name clashes. The intel compiler complained about this, but not gfortran...